### PR TITLE
Enforce consistent spacing inside braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ We keep it simple and follow almost everything defined in the [JavaScript Standa
 - **no** space before function parenthesis
 - **double quotes** for jsx attributes
 - prefer destructuring from objects & arrays
+- enforce spacing inside curly braces
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ module.exports = {
             }
         }, {
             enforceForRenamedProperties: false
-        }]
+        }],
+
+        // Enforce consistent spacing inside braces
+        // https://eslint.org/docs/rules/object-curly-spacing
+        'object-curly-spacing': ['error', 'always']
     }
 }


### PR DESCRIPTION
Always have a space between curly braces and object name.