### PR TITLE
upgraded eslint-plugin-node to 8.0, removed peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Don't be like that cat.
 
 ## Usage
 
-For every project containing JavaScript, ESLint should be set up with this config. For this you need to install all required `peerDependencies` on your own. In one handy command:
+For every project containing JavaScript, ESLint should be set up with this config.
 
 ```bash
-npm install --save-dev eslint eslint-config-oceanprotocol eslint-config-standard eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node eslint-plugin-security
+npm install --save-dev eslint eslint-config-oceanprotocol
 ```
 
 Then, create a new file `.eslintrc` in the root of your project and fill with:
@@ -49,7 +49,7 @@ Then, create a new file `.eslintrc` in the root of your project and fill with:
 When using within a React project use this to get set up:
 
 ```bash
-npm install --save-dev eslint eslint-config-oceanprotocol eslint-config-standard eslint-config-standard-react eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node eslint-plugin-security eslint-plugin-react
+npm install --save-dev eslint eslint-config-oceanprotocol
 ```
 
 And in your `.eslintrc`:

--- a/package.json
+++ b/package.json
@@ -20,23 +20,14 @@
     "styleguide"
   ],
   "devDependencies": {
-    "eslint": "^5.4.0",
-    "eslint-config-standard": "^12.0.0",
-    "eslint-config-standard-react": "^7.0.2",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^7.0.1",
-    "eslint-plugin-promise": "^4.0.0",
-    "eslint-plugin-react": "^7.10.0",
-    "eslint-plugin-security": "^1.4.0",
-    "eslint-plugin-standard": "^4.0.0",
     "release-it": "^7.4.7"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^5.4.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-config-standard-react": "^7.0.2",
     "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-react": "^7.10.0",
     "eslint-plugin-security": "^1.4.0",


### PR DESCRIPTION
* updated eslint-plugin-node to ^8.0.0
* removed need for peer deps, because it clutters everything up. See: https://github.com/oceanprotocol/keeper-contracts/blob/25284ab268fff657bd1035d02ba4d6980acb5131/package.json#L48
It's ok to choose between react and not react version but this will be installed as dev-dep anyway. So why not install both? It's much easier for the maintainer. 